### PR TITLE
Testing PR for WEB-2714 (DO NOT LAND)

### DIFF
--- a/.github/NOTIFIED
+++ b/.github/NOTIFIED
@@ -10,7 +10,6 @@ Be sure to read through .github/Gerald-README.md before adding any rules!
 
 
 
-
 [ON PUSH WITHOUT PULL REQUEST] (DO NOT DELETE THIS LINE)
 
 # Adding yourself below this line will notify you of any changes to this branch that don't go through a pull-request.


### PR DESCRIPTION
## Summary:

This branch has a rule that notifies @yipstanley and @Khan/frontend-infra for * (which doesn't match `.github/NOTIFIED`). In Khan/mobile/pull/1248, note that the same rule exists and Gerald makes a comment that notifies @yipstanley and @Khan/frontend-infra for changes to an empty list of files. This branch (which has changes from WEB-2714) doesn't do that.

## Test plan: