### PR TITLE
Gerald no longer notifies people who have rules that don't match any of the files changed in a pull request

### DIFF
--- a/src/__test__/utils.test.js
+++ b/src/__test__/utils.test.js
@@ -246,24 +246,24 @@ this should show up 2!`;
 });
 
 describe('get filtered lists', () => {
-    it('should work', async () => {
+    it('should work', () => {
         const sampleFile = `# comment
 [ON PULL REQUEST] (DO NOT DELETE THIS LINE)
 
 .github/**          @githubUser!
-*.js                @yipstanley! @githubUser @Org/Slug-name
+**/*.js             @yipstanley! @githubUser @Org/Slug-name
 "/test/ig"          @testperson
 # *                 @otherperson
 
 [ON PUSH WITHOUT PULL REQUEST] (DO NOT DELETE THIS LINE)`;
         const filesChanged = [
-            '.github/workflows/pr-notify.js',
-            '.github/workflows/pr-notify.yml',
+            'src/pr-notify.js',
+            '.github/workflows/pr-actions.yml',
             '.github/NOTIFIED',
         ];
         const fileDiffs = {'yaml.yml': 'this is a function that has added this test line'};
 
-        const {requiredReviewers, reviewers} = await getReviewers(
+        const {requiredReviewers, reviewers} = getReviewers(
             filesChanged,
             fileDiffs,
             'yipstanley',

--- a/src/utils.js
+++ b/src/utils.js
@@ -178,15 +178,16 @@ export const getNotified = (
             // handle dealing with glob matches
             else {
                 const matchedFiles: Array<string> = fg.sync(pattern, globOptions); // flow-uncovered-line
+                console.log(matchedFiles);
                 const intersection = matchedFiles.filter(file => filesChanged.includes(file));
 
+                console.log(intersection);
                 for (const name of names) {
                     pushOrSetToBin(notified, name, intersection);
                 }
             }
         }
     }
-    console.log(notified);
     return notified;
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -186,6 +186,7 @@ export const getNotified = (
             }
         }
     }
+    console.log(notified);
     return notified;
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -178,12 +178,12 @@ export const getNotified = (
             // handle dealing with glob matches
             else {
                 const matchedFiles: Array<string> = fg.sync(pattern, globOptions); // flow-uncovered-line
-                console.log(matchedFiles);
                 const intersection = matchedFiles.filter(file => filesChanged.includes(file));
 
-                console.log(intersection);
-                for (const name of names) {
-                    pushOrSetToBin(notified, name, intersection);
+                if (intersection.length) {
+                    for (const name of names) {
+                        pushOrSetToBin(notified, name, intersection);
+                    }
                 }
             }
         }
@@ -245,15 +245,18 @@ export const getReviewers = (
         } else {
             const matchedFiles: Array<string> = fg.sync(pattern, globOptions); //flow-uncovered-line
             const intersection = matchedFiles.filter(file => filesChanged.includes(file));
-            for (const name of names) {
-                // don't add yourself as a reviewer
-                const {username, justName, isRequired} = parseUsername(name);
-                if (justName === issuer) {
-                    continue;
-                }
 
-                const correctBin = isRequired ? requiredReviewers : reviewers;
-                pushOrSetToBin(correctBin, username, intersection);
+            if (intersection.length) {
+                for (const name of names) {
+                    // don't add yourself as a reviewer
+                    const {username, justName, isRequired} = parseUsername(name);
+                    if (justName === issuer) {
+                        continue;
+                    }
+
+                    const correctBin = isRequired ? requiredReviewers : reviewers;
+                    pushOrSetToBin(correctBin, username, intersection);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary:
Previously, Gerald would notify anyone that had a Gerald rule, even if the rule didn't match any of the files changed. See (Khan/mobile/pull/1248) for an example of this happening. This PR fixes that.

Issue: WEB-2714

## Test plan:
See #13