### PR TITLE
Gerald will now ignore inline comments

### DIFF
--- a/setup-files/NOTIFIED
+++ b/setup-files/NOTIFIED
@@ -6,7 +6,6 @@ Be sure to read through https://khanacademy.atlassian.net/wiki/spaces/FRONTEND/p
 [ON PULL REQUEST] (DO NOT DELETE THIS LINE)
 
 # Notify these people for any changes made to any file
-**/*
 
 
 
@@ -15,5 +14,3 @@ Be sure to read through https://khanacademy.atlassian.net/wiki/spaces/FRONTEND/p
 
 # Adding yourself below this line will notify you of any changes to this branch that don't go through a pull-request.
 # This is analogous to Herald's "Differential Revision is False" condition.
-
-**/*

--- a/setup-files/REVIEWERS
+++ b/setup-files/REVIEWERS
@@ -6,4 +6,3 @@ Be sure to read through https://khanacademy.atlassian.net/wiki/spaces/FRONTEND/p
 [ON PULL REQUEST] (DO NOT DELETE THIS LINE)
 
 # Make these people reviewers for any changes made to any file
-**/*

--- a/src/__test__/utils.test.js
+++ b/src/__test__/utils.test.js
@@ -250,7 +250,8 @@ describe('get reviewers', () => {
     });
 
     it('should ignore inline comments', () => {
-        const reviewersFile = `# comment
+        _mock(readFileSync).mockImplementation(
+            () => `# comment
 *                   @userName
 
 [ON PULL REQUEST] (DO NOT DELETE THIS LINE)
@@ -258,7 +259,8 @@ describe('get reviewers', () => {
 .github/**          @githubUser! # ah yes, the edge case of inline comments
 **/*.js             @yipstanley! @githubUser # these comments shan't bother Gerald, though
 "/test/ig"          @testperson # nope nope it should still work!
-# *                 @otherperson`;
+# *                 @otherperson`,
+        );
         const filesChanged = ['.github/workflows/build.yml', 'src/execCmd.js', 'src/main.js'];
         const fileDiffs = {'yaml.yml': 'this is a function that has added this test line'};
 

--- a/src/__test__/utils.test.js
+++ b/src/__test__/utils.test.js
@@ -262,12 +262,7 @@ describe('get reviewers', () => {
         const filesChanged = ['.github/workflows/build.yml', 'src/execCmd.js', 'src/main.js'];
         const fileDiffs = {'yaml.yml': 'this is a function that has added this test line'};
 
-        const {requiredReviewers, reviewers} = getReviewers(
-            filesChanged,
-            fileDiffs,
-            'yipstanley',
-            reviewersFile,
-        );
+        const {requiredReviewers, reviewers} = getReviewers(filesChanged, fileDiffs, 'yipstanley');
         expect(reviewers).toEqual({
             '@githubUser': ['src/execCmd.js', 'src/main.js'],
             '@testperson': ['yaml.yml'],

--- a/src/__test__/utils.test.js
+++ b/src/__test__/utils.test.js
@@ -177,6 +177,35 @@ describe('get notified', () => {
             '@owner': ['src/execCmd.js', 'src/main.js'],
         });
     });
+
+    it('should ignore inline comments', async () => {
+        const notifiedFile = `# comment
+*                   @userName
+
+[ON PULL REQUEST] (DO NOT DELETE THIS LINE)
+
+.github/**          @githubUser # Gerald is more powerful than this edge case
+**/*.js             @yipstanley @githubUser # inline comments are no problem for the one
+"/test/ig"          @testperson # Mr. Gerald will ignore you now
+# *                 @otherperson
+
+[ON PUSH WITHOUT PULL REQUEST] (DO NOT DELETE THIS LINE)
+
+**/*.js             @owner          # HAH Mr. gerald will also ignore you!`;
+
+        const filesChanged = ['.github/workflows/build.yml', 'src/execCmd.js', 'src/main.js'];
+        const fileDiffs = {'yaml.yml': 'this is a function that has added this test line'};
+
+        expect(await getNotified(filesChanged, fileDiffs, 'pull_request', notifiedFile)).toEqual({
+            '@yipstanley': ['src/execCmd.js', 'src/main.js'],
+            '@githubUser': ['.github/workflows/build.yml', 'src/execCmd.js', 'src/main.js'],
+            '@testperson': ['yaml.yml'],
+        });
+
+        expect(await getNotified(filesChanged, fileDiffs, 'push', notifiedFile)).toEqual({
+            '@owner': ['src/execCmd.js', 'src/main.js'],
+        });
+    });
 });
 
 describe('get reviewers', () => {
@@ -189,6 +218,34 @@ describe('get reviewers', () => {
 .github/**          @githubUser!
 **/*.js             @yipstanley! @githubUser
 "/test/ig"          @testperson
+# *                 @otherperson`;
+        const filesChanged = ['.github/workflows/build.yml', 'src/execCmd.js', 'src/main.js'];
+        const fileDiffs = {'yaml.yml': 'this is a function that has added this test line'};
+
+        const {requiredReviewers, reviewers} = getReviewers(
+            filesChanged,
+            fileDiffs,
+            'yipstanley',
+            reviewersFile,
+        );
+        expect(reviewers).toEqual({
+            '@githubUser': ['src/execCmd.js', 'src/main.js'],
+            '@testperson': ['yaml.yml'],
+        });
+        expect(requiredReviewers).toEqual({
+            '@githubUser': ['.github/workflows/build.yml'],
+        });
+    });
+
+    it('should ignore inline comments', () => {
+        const reviewersFile = `# comment
+*                   @userName
+
+[ON PULL REQUEST] (DO NOT DELETE THIS LINE)
+
+.github/**          @githubUser! # ah yes, the edge case of inline comments
+**/*.js             @yipstanley! @githubUser # these comments shan't bother Gerald, though
+"/test/ig"          @testperson # nope nope it should still work!
 # *                 @otherperson`;
         const filesChanged = ['.github/workflows/build.yml', 'src/execCmd.js', 'src/main.js'];
         const fileDiffs = {'yaml.yml': 'this is a function that has added this test line'};

--- a/src/utils.js
+++ b/src/utils.js
@@ -213,7 +213,7 @@ export const getNotified = (
             let rule = match;
             // ignore inline comments
             if (match.includes('#')) {
-                rule = match.split('#')[0];
+                rule = match.split('#')[0].trim();
             }
             const untrimmedPattern = rule.match(/(.(?!  @))*/);
             const names = rule.match(/@([A-Za-z]*\/)?\S*/g);

--- a/src/utils.js
+++ b/src/utils.js
@@ -206,12 +206,17 @@ export const getNotified = (
         return {};
     }
 
-    const matches = section[0].match(/^[^\#\n].*/gm); // ignore comments
+    const matches = section[0].match(/^[^\#\n].*/gm); // ignore newline comments
     const notified: NameToFiles = {};
     if (matches) {
         for (const match of matches) {
-            const untrimmedPattern = match.match(/(.(?!  @))*/);
-            const names = match.match(/@([A-Za-z]*\/)?\S*/g);
+            let rule = match;
+            // ignore inline comments
+            if (match.includes('#')) {
+                rule = match.split('#')[0];
+            }
+            const untrimmedPattern = rule.match(/(.(?!  @))*/);
+            const names = rule.match(/@([A-Za-z]*\/)?\S*/g);
             if (!untrimmedPattern || !names) {
                 continue;
             }
@@ -262,7 +267,7 @@ export const getReviewers = (
         return {reviewers: {}, requiredReviewers: {}};
     }
 
-    const matches = section[0].match(/^[^\#\n].*/gm); // ignore comments
+    const matches = section[0].match(/^[^\#\n].*/gm); // ignore newline comments
     const reviewers: {[string]: Array<string>, ...} = {};
     const requiredReviewers: {[string]: Array<string>, ...} = {};
     if (!matches) {
@@ -270,8 +275,13 @@ export const getReviewers = (
     }
 
     for (const match of matches) {
-        const untrimmedPattern = match.match(/(.(?!  @))*/);
-        const names = match.match(/@([A-Za-z]*\/)?\S*/g);
+        let rule = match;
+        // ignore inline comments
+        if (match.includes('#')) {
+            rule = match.split('#')[0].trim();
+        }
+        const untrimmedPattern = rule.match(/(.(?!  @))*/);
+        const names = rule.match(/@([A-Za-z]*\/)?\S*/g);
         if (!untrimmedPattern || !names) {
             continue;
         }


### PR DESCRIPTION
## Summary:

While Gerald has always had functionality to ignore newline comments, it was not able to ignore comments that started in the same line as a rule. This PR changes Gerald to check for inline comments and ignore anything that appears after \# in a line. This also adds some tests to make sure that rules with inline comments are interpreted correctly.

Issue: WEB-2745

## Test plan:
Added unit tests, but also see https://github.com/Khan/gerald/pull/26, which is a pull request that has a rule with an inline comment. Note that I am still notified for the correct files, and the message still appears correctly.