### PR TITLE
Reorganized Gerald files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,7 +101,7 @@ module.exports = {
     },
     overrides: [
         {
-            files: ['src/core.js', 'src/execCmd.js', 'src/setup.js'],
+            files: ['src/gerald.js', 'src/execCmd.js', 'src/setup.js'],
             rules: {
                 'import/no-commonjs': 'off',
             },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - run: yarn global add
       - run: npx babel src --out-dir js
         name: Transpile flow to javascript
-      - run: ncc build js/core.js
+      - run: ncc build js/gerald.js
         name: Build dist folder
       - name: Commit files
         run: |

--- a/src/gerald.js
+++ b/src/gerald.js
@@ -6,13 +6,14 @@ require('@babel/register');
 const core = require('@actions/core'); //flow-uncovered-line
 
 const {runOnComment} = require('./runOnComment');
-const {runPullRequest, runPush} = require('./main.js');
+const {runPush} = require('./runOnPush.js');
+const {runOnPullRequest} = require('./runOnPullRequest.js');
 const {context} = require('./setup');
 const {PULL_REQUEST, ENV_EVENT, COMMENT} = require('./constants');
 
 try {
     if (process.env[ENV_EVENT] === PULL_REQUEST) {
-        runPullRequest();
+        runOnPullRequest();
     } else if (process.env[ENV_EVENT] === COMMENT) {
         runOnComment();
     } else {

--- a/src/runOnPush.js
+++ b/src/runOnPush.js
@@ -1,0 +1,69 @@
+// @flow
+
+import {getNotified, getFileDiffs} from './utils';
+import {execCmd} from './execCmd';
+import {ownerAndRepo, extraPermGithub, type Context} from './setup';
+import {PUSH, GERALD_COMMIT_COMMENT_HEADER} from './constants';
+
+const makeCommitComment = async (
+    peopleToFiles: {[string]: Array<string>, ...},
+    commitSHA: string,
+) => {
+    const names: string[] = Object.keys(peopleToFiles);
+    if (peopleToFiles && names.length) {
+        let body: string = GERALD_COMMIT_COMMENT_HEADER;
+        names.forEach((person: string) => {
+            const files = peopleToFiles[person];
+            body += `${person} for changes to \`${files.join('`, `')}\`\n`;
+        });
+
+        await extraPermGithub.repos.createCommitComment({
+            ...ownerAndRepo,
+            commit_sha: commitSHA,
+            body: body,
+        });
+    }
+};
+
+export const runPush = async (usedContext: Context) => {
+    // loop through each commit in the push
+    let prevCommit = usedContext.payload.before;
+    for (const commit of usedContext.payload.commits) {
+        const commitData = await extraPermGithub.git.getCommit({
+            ...ownerAndRepo,
+            commit_sha: commit.id,
+        });
+
+        // commits with >1 parent are merge commits. we want to ignore those
+        if (commitData.data.parents.length === 1) {
+            const filesChanged = (
+                await execCmd('git', [
+                    'diff',
+                    `${prevCommit}...${commitData.data.sha}`,
+                    '--name-only',
+                ])
+            ).split('\n');
+            const fileDiffs = await getFileDiffs(`${prevCommit}...${commitData.data.sha}`);
+            const notified = getNotified(filesChanged, fileDiffs, PUSH);
+
+            await makeCommitComment(notified, commitData.data.sha);
+        }
+
+        // we also want to ignore the diff of a merge commit
+        prevCommit = commitData.data.sha;
+    }
+};
+
+export type __TestCommit = {
+    author: '__testAuthor',
+    comment_count: -1,
+    committer: '__testCommitter',
+    id: string,
+    message: string,
+    tree: '__TESTING__',
+    url: '__TESTING__',
+    verification: '__TESTING__',
+};
+
+export const __makeCommitComment = makeCommitComment;
+export const __extraPermGithub = extraPermGithub;

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,6 +33,23 @@ import {
 type Section = 'pull_request' | 'push';
 type GeraldFile = 'NOTIFIED' | 'REVIEWERS';
 type NameToFiles = {[name: string]: string[], ...};
+type CommentHeaders = 'Reviewers:\n' | 'Required reviewers:\n' | 'Notified:\n';
+
+export const makeCommentBody = (
+    peopleToFiles: {[string]: Array<string>, ...},
+    sectionHeader: CommentHeaders,
+) => {
+    const names: string[] = Object.keys(peopleToFiles);
+    if (names.length) {
+        let body = `### ${sectionHeader}`;
+        names.forEach((person: string) => {
+            const files = peopleToFiles[person];
+            body += `${person} for changes to \`${files.join('`, `')}\`\n\n`;
+        });
+        return body;
+    }
+    return '';
+};
 
 /**
  * @desc Parse the ./.geraldignore and ./.gitignore style of files. Ignore new lines


### PR DESCRIPTION
## Summary:

Renamed `core.js` to `gerald.js`. `runPullRequest` functionality was taken out of `main.js` into a `runOnPullRequest.js` file, and `main.js` was renamed to `runOnPush.js`. This also meant that some tests had to be reorganized and `makeCommitComment` had to be put in `utils.js`.

Issue: WEB-2751

## Test plan:
Unit tests still pass, no logic was changed.