### PR TITLE
No longer look for comments made by Khan-actions-bot

### DIFF
--- a/src/__test__/utils.test.js
+++ b/src/__test__/utils.test.js
@@ -348,7 +348,7 @@ describe('get filtered lists', () => {
 describe('parse existing comments', () => {
     it('should work', () => {
         const gerald = {
-            user: {login: 'khan-actions-bot'},
+            user: {login: 'not-khan-actions-bot'},
             body: `# Gerald:
 
             ## Notified:

--- a/src/utils.js
+++ b/src/utils.js
@@ -405,7 +405,7 @@ export const parseExistingComments = <
 
     existingComments.data.map(cmnt => {
         // only look at comments made by github-actions[bot] for <required> reviewers / notified comments
-        if (cmnt.user.login === 'khan-actions-bot') {
+        if (cmnt.body.match(MATCH_GERALD_COMMENT_HEADER_REGEX)) {
             actionBotComments.push(cmnt);
         } else {
             const removeMeMatch = cmnt.body.match(MATCH_REMOVEME_TAG_REGEX);

--- a/src/utils.js
+++ b/src/utils.js
@@ -387,7 +387,7 @@ export const getFilteredLists = (
 
 /**
  * @desc Parse existing comments on the pull request to get the comments that
- * denote reviewers, required revieweres, and notifiees. Also find all the
+ * denote reviewers, required reviewers, and notifiees. Also find all the
  * #removeme comments to figure out who shouldn't be readded on the pull request.
  * @param existingComments - List of existing Github comments.
  */
@@ -399,14 +399,14 @@ export const parseExistingComments = <
     megaComment: ?T,
     removedJustNames: string[],
 } => {
-    const actionBotComments: T[] = [];
+    const geraldComments: T[] = [];
     const removedJustNames: string[] = [];
     let megaComment: ?T;
 
     existingComments.data.map(cmnt => {
-        // only look at comments made by github-actions[bot] for <required> reviewers / notified comments
+        // only look at comments that start with # Gerald: for <required> reviewers / notified comments
         if (cmnt.body.match(MATCH_GERALD_COMMENT_HEADER_REGEX)) {
-            actionBotComments.push(cmnt);
+            geraldComments.push(cmnt);
         } else {
             const removeMeMatch = cmnt.body.match(MATCH_REMOVEME_TAG_REGEX);
             if (removeMeMatch) {
@@ -415,7 +415,7 @@ export const parseExistingComments = <
         }
     });
 
-    actionBotComments.forEach(comment => {
+    geraldComments.forEach(comment => {
         const megaCommentMatch = comment.body.match(MATCH_GERALD_COMMENT_HEADER_REGEX);
         if (megaCommentMatch) {
             megaComment = comment;


### PR DESCRIPTION
## Summary:
Previously, we were only looking for comments authored by khan-actions-bot to get a list of current reviewers and notifyees. Because this should be open source, we shouldn't limit ourselves to a restriction that specific, as people outside of Khan won't have access to khan-actions-bot. Now, we look for comments that start with '# Gerald:', specifically comments that match /^# Gerald:/.

Issue: WEB-2757

## Test plan:
Unit tests that cover `parseExistingComments` still pass. No other logic was changed