### PR TITLE
Check for verification in runOnPush.js

### DIFF
--- a/src/runOnPush.js
+++ b/src/runOnPush.js
@@ -35,7 +35,8 @@ export const runPush = async (usedContext: Context) => {
         });
 
         // commits with >1 parent are merge commits. we want to ignore those
-        if (commitData.data.parents.length === 1) {
+        // we also want to ignore commits that have been verified.
+        if (commitData.data.parents.length === 1 && !commit.verification.verified) {
             const filesChanged = (
                 await execCmd('git', [
                     'diff',
@@ -62,7 +63,7 @@ export type __TestCommit = {
     message: string,
     tree: '__TESTING__',
     url: '__TESTING__',
-    verification: '__TESTING__',
+    verification: {verified: boolean},
 };
 
 export const __makeCommitComment = makeCommitComment;

--- a/src/setup.js
+++ b/src/setup.js
@@ -34,7 +34,7 @@ export type Context =
                   message: string,
                   tree: '__TESTING__',
                   url: '__TESTING__',
-                  verification: '__TESTING__',
+                  verification: {verified: boolean},
               }>,
           |},
           actor: '__testActor',


### PR DESCRIPTION
## Summary:

If someone wants to be notified of changes pushed to a branch, we should be ignoring any commits that have already been verified. This is because landing a pull-request or merging a branch means pushing verified commits, and if someone has only landed a pull request, it doesn't make sense that people should be notified of the commit that represents the pull request.

Issue: WEB-2776

## Test plan:
Added unit tests