### PR TITLE
Actually remove reviewers instead of just removing it from the Gerald comment

### DIFF
--- a/src/runOnPullRequest.js
+++ b/src/runOnPullRequest.js
@@ -9,6 +9,7 @@ import {
     parseExistingComments,
     getFilteredLists,
     makeCommentBody,
+    maybeRemoveReviewRequests,
 } from './utils';
 import {execCmd} from './execCmd';
 import {ownerAndRepo, context, extraPermGithub} from './setup';
@@ -100,6 +101,7 @@ export const runOnPullRequest = async () => {
         removedJustNames,
     );
 
+    await maybeRemoveReviewRequests(removedJustNames);
     await extraPermGithub.pulls.createReviewRequest({
         ...ownerAndRepo,
         pull_number: context.issue.number,

--- a/src/runOnPullRequest.js
+++ b/src/runOnPullRequest.js
@@ -101,7 +101,11 @@ export const runOnPullRequest = async () => {
         removedJustNames,
     );
 
-    await maybeRemoveReviewRequests(removedJustNames);
+    await maybeRemoveReviewRequests(
+        removedJustNames,
+        {...ownerAndRepo, pull_number: context.issue.number},
+        extraPermGithub,
+    );
     await extraPermGithub.pulls.createReviewRequest({
         ...ownerAndRepo,
         pull_number: context.issue.number,

--- a/src/utils.js
+++ b/src/utils.js
@@ -85,6 +85,9 @@ const filterIgnoreFiles = (fileContents: string): Array<string> => {
  *
  * @param removedJustNames - Just the usernames (not including @) of the people
  * who have requeseted to be removed.
+ * @param params - The owner, repo, and pull_number parameters for Octokit requests.
+ * They can't be imported, because that would make this file really difficult to test.
+ * @param githubClient - The Octokit client that we can make calls on. We also can't import this.
  */
 export const maybeRemoveReviewRequests = async (
     removedJustNames: Array<string>,

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,6 +76,13 @@ const filterIgnoreFiles = (fileContents: string): Array<string> => {
     });
 };
 
+/**
+ * @desc If any of the usernames in removedJustNames are reviewers, we should also
+ * remove them as a reviewer.
+ *
+ * @param removedJustNames - Just the usernames (not including @) of the people
+ * who have requeseted to be removed.
+ */
 export const maybeRemoveReviewRequests = async (removedJustNames: Array<string>) => {
     const {data: reviewRequests} = await extraPermGithub.pulls.listReviewRequests({
         ...ownerAndRepo,


### PR DESCRIPTION
## Summary:
In the past, if someone commented `#RemoveMe` on a pull request, it would remove them from the Gerald megacomment and prevent Gerald from readding them as reviewers in the future, but it doesn't actually remove them as a reviewer. This PR makes it so that Gerald will actually make a request to remove reviewers that have commented `#RemoveMe`.

Issue: WEB-2758

## Test plan:
See (https://github.com/Khan/gerald/pull/35), where Kevin B. was requested for review, and after commenting `#RemoveMe`, his review request was removed.