### PR TITLE
Match regex rules against the squashed diff in runOnPush

### DIFF
--- a/src/__test__/main.test.js
+++ b/src/__test__/main.test.js
@@ -72,9 +72,18 @@ jest.mock('../execCmd.js', () => ({
     ...jest.requireActual('../execCmd.js'),
     execCmd: async (cmd: string, args: string[]) => {
         return await new Promise((res, rej) => {
-            const string = `src/runOnPush.js
+            let string = '';
+            switch (args[1]) {
+                case 'suite3-commit2...suite3-commit3':
+                    string = `src/gerald.js
+.github/workflows/build.yml`;
+                    break;
+                default:
+                    string = `src/runOnPush.js
 src/gerald.js
 .github/workflows/build.yml`;
+                    break;
+            }
             process.nextTick(() => res(string));
         });
     },
@@ -88,9 +97,9 @@ jest.mock('../utils.js', () => ({
     getFileDiffs: async (diffString: string) => {
         // we're going to fake these diffs to force these commits to match a rule
         switch (diffString) {
-            case 'suite2-commit3...suite2-commit4':
-            case 'suite3-commit1...suite3-commit2':
-            case 'suite4-commit1...suite4-commit2':
+            case 'suite2-commit1...suite2-commit5':
+            case 'suite3-commit1...suite3-commit3':
+            case 'suite4-commit1...suite4-commit3':
                 return {'src/runOnPush.js': '+ this line was added'};
             default:
                 return {};

--- a/src/__test__/main.test.js
+++ b/src/__test__/main.test.js
@@ -1,4 +1,4 @@
-// // @flow
+// @flow
 
 import {__makeCommitComment, runPush, __extraPermGithub} from '../runOnPush';
 import {readFileSync} from '../fs';
@@ -72,18 +72,9 @@ jest.mock('../execCmd.js', () => ({
     ...jest.requireActual('../execCmd.js'),
     execCmd: async (cmd: string, args: string[]) => {
         return await new Promise((res, rej) => {
-            let string = '';
-            switch (args[1]) {
-                case 'suite3-commit2...suite3-commit3':
-                    string = `src/gerald.js
-.github/workflows/build.yml`;
-                    break;
-                default:
-                    string = `src/runOnPush.js
+            const string = `src/runOnPush.js
 src/gerald.js
 .github/workflows/build.yml`;
-                    break;
-            }
             process.nextTick(() => res(string));
         });
     },
@@ -98,8 +89,10 @@ jest.mock('../utils.js', () => ({
         // we're going to fake these diffs to force these commits to match a rule
         switch (diffString) {
             case 'suite2-commit1...suite2-commit5':
+            case 'suite2-commit3...suite2-commit4':
             case 'suite3-commit1...suite3-commit3':
             case 'suite4-commit1...suite4-commit3':
+            case 'suite4-commit2...suite4-commit3':
                 return {'src/runOnPush.js': '+ this line was added'};
             default:
                 return {};

--- a/src/runOnPush.js
+++ b/src/runOnPush.js
@@ -48,11 +48,19 @@ export const runPush = async (usedContext: Context) => {
                     '--name-only',
                 ])
             ).split('\n');
+            const thisDiff = await getFileDiffs(`${prevCommit}...${commitData.data.sha}`);
 
             // get the squashed diffs of the files that were changed in this commit
             const fileDiffs = {};
             for (const file of filesChanged) {
-                fileDiffs[file] = squashedDiffs[file];
+                if (thisDiff[file] && squashedDiffs[file]) {
+                    const diffByLines = thisDiff[file].split('\n');
+                    const squashedDiffByLines = squashedDiffs[file].split('\n');
+                    const committedAndSquashedDiff = diffByLines.filter(line =>
+                        squashedDiffByLines.includes(line),
+                    );
+                    fileDiffs[file] = committedAndSquashedDiff;
+                }
             }
             const notified = getNotified(filesChanged, fileDiffs, PUSH);
 

--- a/src/runOnPush.js
+++ b/src/runOnPush.js
@@ -26,8 +26,12 @@ const makeCommitComment = async (
 };
 
 export const runPush = async (usedContext: Context) => {
-    // loop through each commit in the push
     let prevCommit = usedContext.payload.before;
+
+    // we only want to look at the squashed diff for each file
+    const squashedDiffs = await getFileDiffs(`${prevCommit}...${usedContext.payload.after}`);
+
+    // loop through each commit in the push
     for (const commit of usedContext.payload.commits) {
         const commitData = await extraPermGithub.git.getCommit({
             ...ownerAndRepo,
@@ -44,7 +48,12 @@ export const runPush = async (usedContext: Context) => {
                     '--name-only',
                 ])
             ).split('\n');
-            const fileDiffs = await getFileDiffs(`${prevCommit}...${commitData.data.sha}`);
+
+            // get the squashed diffs of the files that were changed in this commit
+            const fileDiffs = {};
+            for (const file of filesChanged) {
+                fileDiffs[file] = squashedDiffs[file];
+            }
             const notified = getNotified(filesChanged, fileDiffs, PUSH);
 
             await makeCommitComment(notified, commitData.data.sha);

--- a/src/runOnPush.js
+++ b/src/runOnPush.js
@@ -54,8 +54,11 @@ export const runPush = async (usedContext: Context) => {
             const fileDiffs = {};
             for (const file of filesChanged) {
                 if (thisDiff[file] && squashedDiffs[file]) {
+                    // get all the diff lines in *this* commit and *all* commits
                     const diffByLines = thisDiff[file].split('\n');
                     const squashedDiffByLines = squashedDiffs[file].split('\n');
+
+                    // only run the regex on the diff lines that are both in *this* commit and all commits
                     const committedAndSquashedDiff = diffByLines.filter(line =>
                         squashedDiffByLines.includes(line),
                     );

--- a/src/runOnPush.js
+++ b/src/runOnPush.js
@@ -51,7 +51,7 @@ export const runPush = async (usedContext: Context) => {
             const thisDiff = await getFileDiffs(`${prevCommit}...${commitData.data.sha}`);
 
             // get the squashed diffs of the files that were changed in this commit
-            const fileDiffs = {};
+            const fileDiffs: {[string]: string, ...} = {};
             for (const file of filesChanged) {
                 if (thisDiff[file] && squashedDiffs[file]) {
                     // get all the diff lines in *this* commit and *all* commits
@@ -62,7 +62,7 @@ export const runPush = async (usedContext: Context) => {
                     const committedAndSquashedDiff = diffByLines.filter(line =>
                         squashedDiffByLines.includes(line),
                     );
-                    fileDiffs[file] = committedAndSquashedDiff;
+                    fileDiffs[file] = committedAndSquashedDiff.join('\n');
                 }
             }
             const notified = getNotified(filesChanged, fileDiffs, PUSH);


### PR DESCRIPTION
## Summary:

Previously, Gerald would test regex rules against the diff between each commit in a push and ignore merge commits and validated commits. This was fine, except it would not work very well for the case where someone made a commit that matched a rule, and then reverted that commit or change in the next commit. This PR changes Gerald so that we look at the squashed diff *and* the commit's diff so that we only notify people on a commit if that commit includes changes that match their regex *and* actually ned up in the final code.

Issue: WEB-2762

## Test plan:
Notice how this commit doesn't notify @yipstanley for changes to `src/runOnPush.js`, even though the `.github/NOTIFIED` file has a rule that notifies @yipstanley on changes that match `/\+/m`, which the change to `src/runOnPush.js` satisfies.
https://github.com/Khan/gerald/commit/60bf3c4f32be44831778a6917df77c10546f02f5

That's because this commit was pushed along with this commit, which removed the line that was added in `src/runOnPush.js`. This means that the final squashed diff doesn't actually change `src/runOnPush.js`, so Gerald won't consider that an actual change, whereas the change in `src/runOnComment.js` didn't get undone, so it is counted as an actual change.
https://github.com/Khan/gerald/commit/f68fbeb98daf4d1d3f19c5f860996834dd969a22