### PR TITLE
Sometimes commit.verification was undefined, causing Gerald to crash

### DIFF
--- a/src/runOnPush.js
+++ b/src/runOnPush.js
@@ -36,7 +36,8 @@ export const runPush = async (usedContext: Context) => {
 
         // commits with >1 parent are merge commits. we want to ignore those
         // we also want to ignore commits that have been verified.
-        if (commitData.data.parents.length === 1 && !commit.verification.verified) {
+        const verified = commit.verification && commit.verification.verified;
+        if (commitData.data.parents.length === 1 && !verified) {
             const filesChanged = (
                 await execCmd('git', [
                     'diff',


### PR DESCRIPTION
## Summary:

This is a small change to Gerald that ensures that Gerald doesn't crash if a commit doesn't have a verification object. Sometimes, commits don't have a verification object, and Gerald will get a property of the verification object, which would crash if the verification object doesn't exist. This PR changes Gerald so that we also check if the verification object exists before †rying to get that property. If the verification object doesn't exist, we treat it as if the commit is not verified.

## Test plan:
I found this bug while making commits to the `debug` branch. Previously, Gerald would straight-up crash, and it doesn't do that when I push to `debug` anymore.