### PR TITLE
Make requests only to people/teams that have not reviewed

### DIFF
--- a/flow-typed/npm/@octokit/rest_vx.x.x.js
+++ b/flow-typed/npm/@octokit/rest_vx.x.x.js
@@ -23479,6 +23479,10 @@ declare module '@octokit/rest' {
         Octokit$TeamsListMembersResponseItem,
     >;
 
+    declare type Octokit$TeamsListMembersInOrgResponse = Array<
+        Octokit$TeamsListMembersResponseItem,
+    >;
+
     declare type Octokit$TeamsListPendingInvitationsResponse = Array<
         Octokit$TeamsListPendingInvitationsResponseItem,
     >;

--- a/flow-typed/npm/@octokit/rest_vx.x.x.js
+++ b/flow-typed/npm/@octokit/rest_vx.x.x.js
@@ -38503,7 +38503,18 @@ declare module '@octokit/rest' {
                 ): Promise<Octokit$Response<Octokit$TeamsListMembersResponse>>,
                 endpoint: Octokit$Endpoint,
             },
+            /**
+             * Team members will include the members of child teams.
+             *
+             * To list members in a team, the team must be visible to the authenticated user.
+             */
+            listMembersInOrg: {
+            (
+                params?: Octokit$RequestOptions & Octokit$TeamsListMembersInOrgParams
+            ): Promise<Octokit$Response<Octokit$TeamsListMembersInOrgResponse>>;
 
+            endpoint: Octokit$Endpoint;
+            },
             /**
              * The return hash contains a `role` field which refers to the Organization Invitation role and will be one of the following values: `direct_member`, `admin`, `billing_manager`, `hiring_manager`, or `reinstate`. If the invitee is not a GitHub member, the `login` field in the return hash will be `null`.
              */

--- a/src/__test__/utils.test.js
+++ b/src/__test__/utils.test.js
@@ -485,7 +485,7 @@ describe('test that makeCommentBody makes a nicely-formatted string', () => {
 
         expect(result).toMatchInlineSnapshot(`
             "### Reviewers:
-            @yipstanley for changes to \`src/runOnPush.js\`, \`.github/workflows/build.yml\`, \`flow-typed/npm/\\\\@octokit/rest_vx.x.x.js\`
+            @yipstanley for changes to \`src/runOnPush.js\`, \`.github/workflows/build.yml\`, \`flow-typed/npm/%40@octokit/rest_vx.x.x.js\`
 
             @Khan/frontend-infra for changes to \`src/runOnPush.js\`, \`.geraldignore\`
 

--- a/src/__test__/utils.test.js
+++ b/src/__test__/utils.test.js
@@ -473,7 +473,11 @@ describe('test that ignore files are parsed correctly', () => {
 describe('test that makeCommentBody makes a nicely-formatted string', () => {
     it('should format the Gerald pull request comment correctly', async () => {
         const peopleToFiles = {
-            '@yipstanley': ['src/runOnPush.js', '.github/workflows/build.yml'],
+            '@yipstanley': [
+                'src/runOnPush.js',
+                '.github/workflows/build.yml',
+                'flow-typed/npm/@octokit/rest_vx.x.x.js',
+            ],
             '@Khan/frontend-infra': ['src/runOnPush.js', '.geraldignore'],
         };
 
@@ -481,7 +485,7 @@ describe('test that makeCommentBody makes a nicely-formatted string', () => {
 
         expect(result).toMatchInlineSnapshot(`
             "### Reviewers:
-            @yipstanley for changes to \`src/runOnPush.js\`, \`.github/workflows/build.yml\`
+            @yipstanley for changes to \`src/runOnPush.js\`, \`.github/workflows/build.yml\`, \`flow-typed/npm/\\\\@octokit/rest_vx.x.x.js\`
 
             @Khan/frontend-infra for changes to \`src/runOnPush.js\`, \`.geraldignore\`
 

--- a/src/runOnPullRequest.js
+++ b/src/runOnPullRequest.js
@@ -70,7 +70,7 @@ const makeReviewRequests = async (reviewers: Array<string>, teamReviewers: Array
         ...ownerAndRepo,
         pull_number: context.issue.number,
     });
-    const alreadyReviewed = reviews.map(review => review.user.login);
+    const alreadyReviewed: Array<string> = reviews.map(review => review.user.login);
 
     // unfulfilled reviewers = everyone who hasn't reviewed
     const unfulfilledReviewers = reviewers.filter(reviewer => !alreadyReviewed.includes(reviewer));

--- a/src/runOnPullRequest.js
+++ b/src/runOnPullRequest.js
@@ -65,14 +65,15 @@ const updatePullRequestComment = async (
 };
 
 const makeReviewRequests = async (reviewers: Array<string>, teamReviewers: Array<string>) => {
+    // figure out who has already reviewed
     const {data: reviews} = await extraPermGithub.pulls.listReviews({
         ...ownerAndRepo,
         pull_number: context.issue.number,
     });
+    const alreadyReviewed = reviews.map(review => review.user.login);
 
-    const reviewed = reviews.map(review => review.user.login);
-
-    const unfulfilledReviewers = reviewers.filter(reviewer => !reviewed.includes(reviewer));
+    // unfulfilled reviewers = everyone who hasn't reviewed
+    const unfulfilledReviewers = reviewers.filter(reviewer => !alreadyReviewed.includes(reviewer));
     const unfulfilledTeams = teamReviewers;
 
     for (const team of teamReviewers) {
@@ -81,7 +82,9 @@ const makeReviewRequests = async (reviewers: Array<string>, teamReviewers: Array
             team_slug: team,
         });
         const members = membership.map(member => member.login);
-        for (const reviewer of reviewed) {
+
+        // if a requested team has a review from a member, consider it fulfilled
+        for (const reviewer of alreadyReviewed) {
             if (members.includes(reviewer)) {
                 unfulfilledTeams.splice(unfulfilledTeams.indexOf(team), 1);
                 break;

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,7 +51,7 @@ export const makeCommentBody = (
             const files = peopleToFiles[person];
             const filesText = files.join('`, `');
             // escape @ symbols in our files
-            const escapedFilesText = filesText.replace(/@/g, '\\@');
+            const escapedFilesText = filesText.replace(/@/g, '%40@');
             body += `${person} for changes to \`${escapedFilesText}\`\n\n`;
         });
         return body;

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,7 +49,10 @@ export const makeCommentBody = (
         let body = `### ${sectionHeader}`;
         names.forEach((person: string) => {
             const files = peopleToFiles[person];
-            body += `${person} for changes to \`${files.join('`, `')}\`\n\n`;
+            const filesText = files.join('`, `');
+            // escape @ symbols in our files
+            const escapedFilesText = filesText.replace(/@/g, '\\@');
+            body += `${person} for changes to \`${escapedFilesText}\`\n\n`;
         });
         return body;
     }


### PR DESCRIPTION
## Summary:

Previously, if Gerald requested a review from Khan/team1 and owner1, and owner1 and a member of Khan/team1 reviewed the pull request, Gerald would rerequest reviews from KHan/team1 and owner1 if the pull request was updated. This PR changes Gerald so that it doesn't request reviews from people or teams that have already reviewed the pull request.

There was also a bug here where the change to `@octokit/rest_vx.x.x.js` was being interpreted as a team and failing on `git land`. This also fixes that by escaping all `@` symbols with `%40`.

Issue: WEB-2795

## Test plan:
https://github.com/Khan/gerald/pull/52