### PR TITLE
Add a check/step to run yarn build when js src files have changed

### DIFF
--- a/.github/workflow-templates/pr-autofix.yml
+++ b/.github/workflow-templates/pr-autofix.yml
@@ -27,6 +27,11 @@ jobs:
       setup: yarn
       run: node ./node_modules/actions-utils/list-changed-files.js | grep '.*\.js$' | xargs npm run -s format-files
 
+    - name: Rebuild our "dist" file
+      setup: yarn
+      paths: src/**
+      run: yarn build
+
     - uses: Khan/autofix-commit-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -29,6 +29,25 @@ jobs:
           echo "::set-output name=changed::false"
 
           exit 0
+      - id: paths_src_
+        name: 'Check paths: src/**'
+        run: >-
+          BASE=${GITHUB_BASE_REF:-HEAD~1}
+
+          if [[ -n $(git diff --name-only refs/remotes/origin/$BASE --relative |
+          grep '^src/.*$') ]]
+
+          then
+
+          echo "::set-output name=changed::true"
+
+          exit 0
+
+          fi
+
+          echo "::set-output name=changed::false"
+
+          exit 0
       - run: yarn
         name: '▶️ Setup yarn: '
       - name: Rebuild github actions workflow
@@ -38,6 +57,9 @@ jobs:
         run: >-
           node ./node_modules/actions-utils/list-changed-files.js | grep
           '.*\.js$' | xargs npm run -s format-files
+      - name: Rebuild our "dist" file
+        run: yarn build
+        if: steps.paths_src_.outputs.changed == 'true'
       - uses: Khan/autofix-commit-action@master
         env:
           GITHUB_TOKEN: '${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}'


### PR DESCRIPTION
## Summary:
I always forget that I have to do this, and then my changes don't take effect. This runs `yarn build` automatically and commits the result.

Issue: XXX-XXXX

## Test plan:
Make a change in a file under `src`, make a PR, see that `yarn build` gets run and the `dist` file changed. [It worked!](https://github.com/Khan/gerald/pull/61)