### PR TITLE
Add concurrency to cancel stale gerald pr runs in gerald-pr.yml

### DIFF
--- a/.github/workflows/gerald-pr.yml
+++ b/.github/workflows/gerald-pr.yml
@@ -7,7 +7,11 @@ name: Gerald - Notify and Request Reviewers On Pull Request
     # We also add "edited" to re-check when the base branch
     # is changed.
     types: [opened, synchronize, reopened, ready_for_review, edited]
-
+# When a new revision is pushed to a PR, cancel all in-progress CI runs for that
+# PR. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   gerald:
     # Don't re-run if only the title or body changes


### PR DESCRIPTION
GitHub Pull request shouldn't bother with stale Gerald notification runs when they've already been updated (and possibly corrected). Gerald currently triggers for `edited, opened, reopened, ready_for_review, synchronize` and a user can very quickly trigger all of them... which currently plod along in parallel wasting money, and repeatedly notifying the same people on Slack (depending on their settings).

TYPE | DESCRIPTION
-- | --
opened | pull request is created
edited | title, body, or the base branch of the PR is modified
ready_for_review | pull request is taken out from draft mode
reopened | closed pull request is reopened
synchronize | commit(s) pushed to the pull request