### PR TITLE
Add some guidance on contributing and bump version

### DIFF
--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -14,7 +14,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Get All Changed Files
-        uses: Khan/actions@get-changed-files-v1
+        uses: Khan/actions@get-changed-files-v2
         id: changed
         with:
           directories: src/

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -28,11 +28,11 @@ jobs:
           extensions: '.js'
 
       - name: Run prettier
-        if: steps.changed-js.outputs.filtered != ''
-        run: yarn run format-files ${{ steps.changed-js.outputs.filtered }}
+        if: steps.changed-js.outputs.filtered != '[]'
+        run: echo '${{ steps.changed-js.outputs.filtered }}' | jq -r .[] | xargs yarn run format-files
 
       - name: Rebuild our "dist" file
-        if: steps.changed.outputs.files != ''
+        if: steps.changed.outputs.files != '[]'
         run: yarn build
 
       - uses: Khan/autofix-commit-action@main

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -13,34 +13,27 @@ jobs:
       - name: Setup Node.js, install deps
         uses: ./.github/actions/setup
 
-      - id: paths_src_
-        name: 'Check paths: src/**'
-        run: >-
-          BASE=${GITHUB_BASE_REF:-HEAD~1}
+      - name: Get All Changed Files
+        uses: Khan/actions@get-changed-files-v1
+        id: changed
+        with:
+          directories: src/
 
-          if [[ -n $(git diff --name-only refs/remotes/origin/$BASE --relative |
-          grep '^src/.*$') ]]
-
-          then
-
-          echo "changed=true" >> $GITHUB_OUTPUT
-
-          exit 0
-
-          fi
-
-          echo "changed=false" >> $GITHUB_OUTPUT
-
-          exit 0
+      - id: changed-js
+        name: Find .js changed files
+        uses: Khan/actions@filter-files-v1
+        if: always()
+        with:
+          changed-files: ${{ steps.changed.outputs.files }}
+          extensions: '.js'
 
       - name: Run prettier
-        run: >-
-          node ./node_modules/actions-utils/list-changed-files.js | grep
-          '.*\.js$' | xargs npm run -s format-files
+        if: steps.changed-js.outputs.filtered != ''
+        run: yarn run format-files ${{ steps.changed-js.outputs.filtered }}
 
       - name: Rebuild our "dist" file
+        if: steps.changed.outputs.files != ''
         run: yarn build
-        if: steps.paths_src_.outputs.changed == 'true'
 
       - uses: Khan/autofix-commit-action@main
         env:

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -42,6 +42,6 @@ jobs:
         run: yarn build
         if: steps.paths_src_.outputs.changed == 'true'
 
-      - uses: Khan/autofix-commit-action@master
+      - uses: Khan/autofix-commit-action@main
         env:
           GITHUB_TOKEN: '${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}'

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -23,13 +23,13 @@ jobs:
 
           then
 
-          echo "::set-output name=changed::true"
+          echo "changed=true" >> $GITHUB_OUTPUT
 
           exit 0
 
           fi
 
-          echo "::set-output name=changed::false"
+          echo "changed=false" >> $GITHUB_OUTPUT
 
           exit 0
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at opensource[at]khanacademy[dot]org. All
+complaints will be reviewed and investigated and will result in a response deemed
+necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to `wonder-stuff`
+
+🙇Thank you for your interest in contributing to the Gerald repository. However, **we are not currently accepting community contributions** on this project.
+
+The participation of others is a wonderful 🎁gift. When we are ready to accept that gift, we will update these guidelines.
+If you have already been invited to participate, the remainder of these guidelines are for you.
+
+📖 Be sure to read our [Code of Conduct](https://github.com/Khan/gerald/blob/main/CODE_OF_CONDUCT.md).
+
+## 🛑 Bugs And Feature Requests
+
+⚠️ **We are not currently accepting externally raised bugs and feature requests**
+
+## 💻 Code Changes
+
+⚠️ **We are not currently accepting externally provided code changes**
+
+### ⓵ Making your first change
+
+If you are eligible to make changes, check with the maintainers for a good first issue and we'll help get you going.
+
+### 🎬 Getting Started
+
+To work in the `gerald` repository, follow these steps:
+
+1. Clone the repository
+   `gh repo clone Khan/wonder-stuff`
+2. Install `yarn` (see [🔗yarnpkg.com](https://yarnpkg.com))
+3. Run `yarn install` to install the dependencies
+
+You can now work on `gerald`. We prefer [🔗Visual Studio Code](https://code.visualstudio.com/) as our development environment (it's cross-platform and awesome), but please use what you feel comfortable with (we'll even forgive you for using vim).
+
+### 🧪 Code Quality
+
+#### Manual
+
+We love code reviews. If there are open pull requests, please feel free to review them and provide feedback. Feedback is a gift and code reviews are often a bottleneck in getting new things released. Jump in, even if you don't know anything; you probably know more than you think.
+
+💭**REMEMBER** Be kind and considerate. Folks are volunteering their time and code reviews are a moment of vulnerability where a criticism of the code can easily become a criticism of the individual that wrote it.
+
+1. Take your time
+2. Consider how you might receive the feedback you are giving if it were attached to code you wrote
+3. Favor asking questions over prescribing solutions.
+
+#### Automated
+
+To ensure code quality, we use prettier, Flow, eslint, and jest. These are executed automatically by the workflows.
+
+To execute these operations outside of a pull request or commit operation, you can use `yarn`.
+
+- `yarn flow`
+- `yarn lint`
+- `yarn test`
+- `yarn format`
+
+💭**REMEMBER** If you would like to contribute code changes to the project, first make sure there's a corresponding issue for the change you wish to make.
+
+## 📦 Build And Publish
+
+Anyone can create a local build of the distributed code by running `yarn build`. Our `pr-autofix` workflow will also perform this process and commit the result.
+
+### Publishing
+
+Once changes are landed to `main` and the `dist` directory is up-to-date, you should bump the version in the `package.json` (either major or minor version), commit and land that change to `main` via a PR, and then create a tag in the format `vX.Y` where `X.Y` is the version number. Then push the tag to GitHub with `git push --tags`.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.0",
+  "version": "4.0.0",
   "scripts": {
     "build": "rm -rf js && babel src/*.js -d js/ && npm run dist",
     "dist": "ncc build js/gerald.js",

--- a/src/execCmd.js
+++ b/src/execCmd.js
@@ -4,7 +4,7 @@ const exec = require('@actions/exec'); //flow-uncovered-line
 
 /**
  * @desc Asynchronously calls @actions/exec to execute a command.
- * @param cmd - Command that we are calling.
+ * @param cmd - The command that we are calling.
  * @param args - List of arguments to call with the command.
  * @throws if the command errors.
  */


### PR DESCRIPTION
## Summary:
This PR adds a `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md` file to the repository, which were copied from Wonder Stuff before tweaking `CONTRIBUTING.md` to cover Gerald's specifics.

This also bumps the `package.json` to version `4.0.0`, ready for a new tag once this lands.

This PR also should test the updated autofix action, which hopefully means no more Node16 deprecation warnings.

Issue: FEI-5545

## Test plan:
I did a `yarn build` locally to check the `dist` changes. Pushing this PR up should trigger our workflow runs to verify they are correct.