### PR TITLE
[🔥AUDIT🔥] Remove version of ncc we don't use

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
       - name: Setup Node.js, install deps
         uses: ./.github/actions/setup
 
-      - run: sudo npm i -g @zeit/ncc
-
       - name: Build dist folder
         run: yarn run build
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We already use `@vercel/ncc`, we don't need this global install of a deprecated thing that recommends moving to `@vercel/ncc`.

Issue: FEI-5545

## Test plan:
Let this workflow run and see that it just works without the deprecation notice.