### PR TITLE
[🔥AUDIT🔥] Update to latest gerald-pr action

### DIFF
--- a/.github/workflows/gerald-pr.yml
+++ b/.github/workflows/gerald-pr.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
-      - uses: Khan/actions@gerald-pr-v2
+      - uses: Khan/actions@gerald-pr-v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           admin-token: ${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This updates our PR workflow. We don't need to tag a new release for this, just closing the loop on the Node 20 update to get rid of Node 16 deprecation.

Issue: FEI-5484

## Test plan:
See that the workflow no longer shows a Node 16 deprecation notice.