### PR TITLE
Bump version in example file to use Khan/actions@gerald-pr-v3

### DIFF
--- a/setup-files/gerald-pr.yml
+++ b/setup-files/gerald-pr.yml
@@ -13,7 +13,7 @@ jobs:
     if: "github.event.action != 'edited' || github.event.changes.base != null"
     runs-on: ubuntu-latest
     steps:
-      - uses: Khan/actions@gerald-pr-v2
+      - uses: Khan/actions@gerald-pr-v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           admin-token: ${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
## Summary:
This points the example file to the version that fixes bug FEI-5620.

I should have included this in my last PR... I might re-point the currently tagged version to this sha when I land, so that tip of `main` isn't ahead of the last tag.

Issue: FEI-5620

## Test plan:
See that the bug is fixed in this repo by having a Gerald-added-team-member comment on a draft PR then promote it