### PR TITLE
Switch back to using major-only versions for actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
       with:
         run_install: false
 

--- a/.github/workflows/gerald-comment.yml
+++ b/.github/workflows/gerald-comment.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Gerald
-        uses: Khan/gerald@5b4582365dafc568f0f67d29f7db637bd0c2ddf9 # main
+        uses: Khan/gerald@c8adc7c2ff208e7a0a76b48d660d00e406d17ee4 # main
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           ADMIN_PERMISSION_TOKEN: '${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}'

--- a/.github/workflows/gerald-pr.yml
+++ b/.github/workflows/gerald-pr.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
-      - uses: Khan/actions@4d214ec8e52a4d617fe1ba2a56dda8ff1bc3f0dd # gerald-pr-v3.1.7
+      - uses: Khan/actions@14c32221dcaf87e592416d6a4de5d85924d899b7 # gerald-pr-v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           admin-token: ${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/gerald-push.yml
+++ b/.github/workflows/gerald-push.yml
@@ -16,7 +16,7 @@ jobs:
           # We add one to the length because we want to get the diff between the last commit and the commit before the first commit.
           fetch-depth: '$(node -e "console.log(${{ github.event.commits }}.length + 1)")'
       - name: Run Gerald
-        uses: Khan/gerald@5b4582365dafc568f0f67d29f7db637bd0c2ddf9 # main
+        uses: Khan/gerald@c8adc7c2ff208e7a0a76b48d660d00e406d17ee4 # main
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           ADMIN_PERMISSION_TOKEN: '${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}'

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -14,14 +14,14 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Get All Changed Files
-        uses: Khan/actions@42489a21fc83e59db35ae5be08209db29981c823 # get-changed-files-v2.1.4
+        uses: Khan/actions@c72fbe11ecb7b2d2e327d5e372c4e90bd461e233 # get-changed-files-v2
         id: changed
         with:
           directories: src/
 
       - id: changed-js
         name: Find .js changed files
-        uses: Khan/actions@b0a6a316f61b34d7eed199051f1130247c86cee1 # filter-files-v2.1.2
+        uses: Khan/actions@62b87ee091634f22dbcf87e3cb69e4bd7d6827a7 # filter-files-v2
         if: always()
         with:
           changed-files: ${{ steps.changed.outputs.files }}


### PR DESCRIPTION
## Summary:
In #96 I changed the versions tags in the comments to use pinned versions.  This was due to a change in Khan/actions that stopped the publish script from updating the major-only tags.  https://github.com/Khan/actions/pull/146 has restored this behaviour which means that Khan/gerald can again use major-only versions in comments specifying versions of GitHub actions.

Issue: None

## Test plan:
- see that CI checks pass