### PR TITLE
Update third-party actions to versions that use Node v24

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,12 +5,12 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       with:
         run_install: false
 
     - name: Setup Node
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: "24.x"
         cache: "pnpm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js, install deps
         uses: ./.github/actions/setup
@@ -30,7 +30,7 @@ jobs:
 
       - name: Push changes
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/debug'
-        uses: ad-m/github-push-action@57116acb309081ee57864270b0e3c4cedbe45452 # master
+        uses: ad-m/github-push-action@4cc74773234f74829a8c21bc4d69dd4be9cfa599 # master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}

--- a/.github/workflows/gerald-comment.yml
+++ b/.github/workflows/gerald-comment.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Gerald
-        uses: Khan/gerald@c8adc7c2ff208e7a0a76b48d660d00e406d17ee4 # main
+        uses: Khan/gerald@849ddb6db2db2ca094410b65a4e4a49d96ba7b06 # main
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           ADMIN_PERMISSION_TOKEN: '${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}'

--- a/.github/workflows/gerald-pr.yml
+++ b/.github/workflows/gerald-pr.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
-      - uses: Khan/actions@14c32221dcaf87e592416d6a4de5d85924d899b7 # gerald-pr-v3
+      - uses: Khan/actions@14c32221dcaf87e592416d6a4de5d85924d899b7 # gerald-pr-v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           admin-token: ${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/gerald-pr.yml
+++ b/.github/workflows/gerald-pr.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
-      - uses: Khan/actions@14c32221dcaf87e592416d6a4de5d85924d899b7 # gerald-pr-v4
+      - uses: Khan/actions@e72ebaa4cdd27557152992d6131df8bb5c36c05c # gerald-pr-v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           admin-token: ${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/gerald-push.yml
+++ b/.github/workflows/gerald-push.yml
@@ -9,14 +9,14 @@ jobs:
   gerald:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: '${{ github.ref }}'
           # GitHub Actions doesn't allow us to take the length of github.event.commits, so we have to pass the array into node and take the length there.
           # We add one to the length because we want to get the diff between the last commit and the commit before the first commit.
           fetch-depth: '$(node -e "console.log(${{ github.event.commits }}.length + 1)")'
       - name: Run Gerald
-        uses: Khan/gerald@c8adc7c2ff208e7a0a76b48d660d00e406d17ee4 # main
+        uses: Khan/gerald@849ddb6db2db2ca094410b65a4e4a49d96ba7b06 # main
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           ADMIN_PERMISSION_TOKEN: '${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}'

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js, install deps
         uses: ./.github/actions/setup

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -35,6 +35,6 @@ jobs:
         if: steps.changed.outputs.files != '[]'
         run: pnpm build
 
-      - uses: Khan/autofix-commit-action@7ad29653a245c4bc54859d8644f233f94a99a183 # main
+      - uses: Khan/autofix-commit-action@259499a361ea28f5d93f44b12b5cf0dee9a7b6b4 # main
         env:
           GITHUB_TOKEN: '${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}'

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -8,20 +8,20 @@ jobs:
     if: github.actor != 'khan-actions-bot'
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js, install deps
         uses: ./.github/actions/setup
 
       - name: Get All Changed Files
-        uses: Khan/actions@c72fbe11ecb7b2d2e327d5e372c4e90bd461e233 # get-changed-files-v2
+        uses: Khan/actions@30cadf1146cce2e3cdd2510dc8378063e9b08b58 # get-changed-files-v3
         id: changed
         with:
           directories: src/
 
       - id: changed-js
         name: Find .js changed files
-        uses: Khan/actions@62b87ee091634f22dbcf87e3cb69e4bd7d6827a7 # filter-files-v2
+        uses: Khan/actions@069171ef7dea82ab80a8e499c4217d9b812f6af4 # filter-files-v3
         if: always()
         with:
           changed-files: ${{ steps.changed.outputs.files }}


### PR DESCRIPTION
## Summary:
In addition to update all workflows to use Node v24, we also need to update all third-party actions to versions that use Node v24.

Issue: FEI-7601

## Test plan:
- let CI run and look at the warnings

NOTE:
- gerald-pr.yml uses Khan/actions' action/gerald-pr/action.yml which in turn uses Khan/gerald so I will need to update this repo and that repo again before this warning can be fixed

<img width="622" height="317" alt="Screenshot 2026-03-30 at 5 50 27 PM" src="https://github.com/user-attachments/assets/9f01849c-7477-4137-a8ea-899305044062" />
