### PR TITLE
[🔥AUDIT🔥] Actually update Khan/gerald's action.yml to use node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Gerald Action'
 description: 'Notify and Request Reviewers on Pull Request'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: check-circle


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This is part of ongoing work to update all of our GitHub actions to be using Node v24.

I missed that ./action.yml specified which version of Node it was using.

Issue: None

## Test plan:
- after landing this PR, tag the commit with v5.1
- update https://github.com/Khan/actions/pull/157 to use v5.1 of Khan/gerald
- see that there are no warnings about Node v20 being used by Khan/gerald