### PR TITLE
Remove mise.toml file

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,0 @@
-[tools]
-node = { version = "24.13", postinstall = "corepack enable" }


### PR DESCRIPTION
## Summary:
The global mise config has Node set to 24.13 so the repo-specific mise.toml is no longer needed.

Issue: FEI-7566

## Test plan:
- node -v, see 24.13.1